### PR TITLE
Directional ffs

### DIFF
--- a/antelope_foreground/data_sources/calrecycle_lca.py
+++ b/antelope_foreground/data_sources/calrecycle_lca.py
@@ -343,7 +343,8 @@ class CalRecycleImporter(object):
             frag.clear_termination()
             frag.terminate(term_node, term_flow=term_flow)
             if term_node.origin in private_roots:
-                frag.set_background()
+                # frag.set_background()
+                pass
             else:
                 set_child_exchanges(frag)
         elif ff['NodeTypeID'] == '2':
@@ -369,7 +370,8 @@ class CalRecycleImporter(object):
                 if bg['NodeTypeID'] == '1':
                     term_node = qi.get(bg['TargetUUID'])
                     if term_node.origin in private_roots:
-                        frag.set_background()
+                        pass
+                        # frag.set_background()
                 else:
                     term_node = next(_f for _f in self._fragments.values() if _f.uuid == bg['TargetUUID'])
                 frag.clear_termination()
@@ -412,7 +414,7 @@ class CalRecycleImporter(object):
         uslci_bg_ffids = ('14', '26', '38', '50', '62', '74')
         for i in uslci_bg_ffids:
             frag = self._frags[i]
-            frag.set_background()
+            # frag.set_background()
 
     def inv_ethylene_glycol_correction(self):
         """

--- a/antelope_foreground/entities/fragments.py
+++ b/antelope_foreground/entities/fragments.py
@@ -135,6 +135,7 @@ class LcFragment(LcEntity):
                  term_flow=None,
                  external_ref=None,
                  observe=None,
+                 descend=None,
                  **kwargs):
         """
         Required params:
@@ -146,10 +147,11 @@ class LcFragment(LcEntity):
         :param units: to convert exchange value, if supplied
         :param private: forces aggregation of subfragments (not currently used)
         :param balance_flow: if true, exch val is always ignored and calculated based on parent
-        :param background: if true, fragment only returns LCIA results.
+        :param background: [[DEPRECATED / to be ignored]] if true, ends traversal
         :param termination: specify the fragment's default termination
         :param term_flow: specify the term_flow (ignored if termination is None)
         :param observe: [None] if True, assign observed_ev to match cached_ev
+        :param descend: [None] if a termination is provided, whether to set its descend flag
         :param kwargs:
         """
 
@@ -180,7 +182,7 @@ class LcFragment(LcEntity):
             if 'StageName' not in self._d:
                 self._d['StageName'] = ''
         else:
-            self._terminations[None] = FlowTermination(self, termination, term_flow=term_flow)
+            self._terminations[None] = FlowTermination(self, termination, term_flow=term_flow, descend=descend)
             if 'StageName' not in self._d:
                 stagename = ''
                 try:
@@ -907,7 +909,9 @@ class LcFragment(LcEntity):
                 raise CacheAlreadySet('Scenario termination already set. use clear_termination()')
 
         if scenario is None and term_node in self._terminations:
-            # shortcut: assign an existing scenario to be default
+            # shortcut: assign an existing scenario to be default  ## DWR? this is surely nonstandard-
+            # causes namespace conflicts btwn scenario and external_ref, but not really because the argument is
+            # supposed to be a node. supplying txt as an argument is nonstandard- so it's clearly a hack. eh.
             self._terminations[None] = self._terminations[term_node]
             return self._terminations[term_node]
 

--- a/antelope_foreground/entities/fragments.py
+++ b/antelope_foreground/entities/fragments.py
@@ -81,7 +81,7 @@ class LcFragment(LcEntity):
         if flow is None:
             try:
                 org, ext = j['flow'].split('/')
-                flow = fg.catalog_ref(org, ext)
+                flow = fg.catalog_ref(org, ext, entity_type='flow')
             except ValueError:
                 print('%s: Flow %s not found in foreground %s' % (j['entityId'], j['flow'], fg.ref))
                 flow = LcFlow(j['flow'], Name=j['tags']['Name'], Compartment=['Intermediate Flows', 'Fragments'],

--- a/antelope_foreground/foreground_catalog.py
+++ b/antelope_foreground/foreground_catalog.py
@@ -118,3 +118,16 @@ class ForegroundCatalog(LcCatalog):
                     self.delete_resource(res, delete_source=True)
                 else:
                     print('Unable to apply configuration to resource for %s\nsource: %s' % (res.origin, res.source))
+
+    def delete_foreground(self, foreground, really=False):
+        res = self.get_resource(foreground, 'foreground')
+        self.delete_resource(res)
+        abs_src = self.abs_path(res.source)
+        if really:
+            rmtree(abs_src)
+        else:
+            del_path = abs_src + '-DELETED'
+            if os.path.exists(del_path):
+                rmtree(del_path)
+
+            os.rename(abs_src, del_path)

--- a/antelope_foreground/fragment_flows.py
+++ b/antelope_foreground/fragment_flows.py
@@ -253,7 +253,7 @@ def group_ios(parent, ffs, include_ref_flow=True, passthru_threshold=0.45):
     """
     out = defaultdict(float)
     dirs = dict()
-    cons = dict()
+    # cons = dict()
     internal = []
     external = []
     for ff in ffs:
@@ -267,12 +267,13 @@ def group_ios(parent, ffs, include_ref_flow=True, passthru_threshold=0.45):
             else:
                 magnitude = -ff.magnitude
 
-            # ditto conservation status
+            ''' # ditto conservation status  # but this doesn't work
             if ff.fragment.flow not in cons:
                 cons[ff.fragment.flow] = ff.is_conserved
             else:
                 if ff.is_conserved ^ cons[ff.fragment.flow]:
                     print('** Surprise! conservation status not shared among matching flows %s' % ff.fragment.uuid)
+            '''
 
             out[ff.fragment.flow] += magnitude
         else:
@@ -281,7 +282,7 @@ def group_ios(parent, ffs, include_ref_flow=True, passthru_threshold=0.45):
     # now deal with reference flow-- trivial fragment should wind up with two equal-and-opposite [pass-through] flows
     if include_ref_flow:
         ref_frag = parent.top()
-        ref_cons = ref_frag.is_conserved_parent
+        # ref_cons = ref_frag.is_conserved_parent
         ref_mag = ffs[0].magnitude
         if ref_frag.flow in out:  # either pass through or autoconsumption
             ref_frag.dbg_print('either pass through or autoconsumption')
@@ -315,8 +316,8 @@ def group_ios(parent, ffs, include_ref_flow=True, passthru_threshold=0.45):
                     # A.1.a, A.3.a, A.2, A.4
                     ref_frag.dbg_print('pass thru no effect %g %g' % (val, ref_mag))
                     # pass-thru: pre-initialize external with the reference flow, having the opposite direction
-                    external.append(FragmentFlow.cutoff(parent, ref_frag.flow, comp_dir(auto_dirn), ref_mag,
-                                                        is_conserved=ref_cons))
+                    external.append(FragmentFlow.cutoff(parent, ref_frag.flow, comp_dir(auto_dirn), ref_mag)) #,
+                                                        #is_conserved=ref_cons))
             else:
                 # all case B
                 ref_frag.dbg_print('cumulation! %g %g' % (val, ref_mag))
@@ -326,14 +327,14 @@ def group_ios(parent, ffs, include_ref_flow=True, passthru_threshold=0.45):
         else:
             ref_frag.dbg_print('uncomplicated ref flow')
             # no autoconsumption or pass-through, but we still want the ref flow to show up in the inventory
-            external.append(FragmentFlow.cutoff(parent, ref_frag.flow, comp_dir(ref_frag.direction), ref_mag,
-                                                is_conserved=ref_cons))
+            external.append(FragmentFlow.cutoff(parent, ref_frag.flow, comp_dir(ref_frag.direction), ref_mag)) #,
+                                                #is_conserved=ref_cons))
 
     for flow, value in out.items():
         direction = dirs[flow]
         if value < 0:
             direction = comp_dir(direction)
-        external.append(FragmentFlow.cutoff(parent, flow, direction, abs(value), is_conserved=cons[flow]))
+        external.append(FragmentFlow.cutoff(parent, flow, direction, abs(value))) #, is_conserved=cons[flow]))
 
     return external, internal
 

--- a/antelope_foreground/implementations/foreground.py
+++ b/antelope_foreground/implementations/foreground.py
@@ -304,7 +304,7 @@ class AntelopeForegroundImplementation(BasicImplementation, AntelopeForegroundIn
                                                                                               scenario))
         if termination is not None:
             term = self.find_term(termination)
-            fragment.terminate(term, scenario=scenario)
+            fragment.terminate(term, scenario=scenario, **kwargs)
 
         return fragment.link
 

--- a/antelope_foreground/interfaces/iforeground.py
+++ b/antelope_foreground/interfaces/iforeground.py
@@ -52,28 +52,7 @@ class AntelopeForegroundInterface(ForegroundInterface):
         return self._perform_query(_interface, 'frag', ForegroundRequired,
                                    string, many=many, **kwargs)
 
-    def new_fragment(self, flow, direction, **kwargs):
-        """
-        Create a fragment and add it to the foreground.
-
-        If creating a child flow ('parent' kwarg is non-None), then supply the direction with respect to the parent
-        fragment. Otherwise, supply the direction with respect to the newly created fragment.  Example: for a fragment
-        for electricity production:
-
-        >>> fg = ForegroundInterface(...)
-        >>> elec = fg.new_flow('Electricity supply fragment', 'kWh')
-        >>> my_frag = fg.new_fragment(elec, 'Output')  # flow is an output from my_frag
-        >>> child = fg.new_fragment(elec, 'Input', parent=my_frag, balance=True)  # flow is an input to my_frag
-        >>> child.terminate(elec_production_process)
-
-        :param flow: a flow entity/ref, or an external_ref known to the foreground
-        :param direction:
-        :param kwargs: uuid=None, parent=None, comment=None, value=None, balance=False; **kwargs passed to LcFragment
-        :return: the fragment? or a fragment ref? <== should only be used in the event of a non-local foreground
-        """
-        return self._perform_query(_interface, 'new_fragment', ForegroundRequired,
-                                   flow, direction, **kwargs)
-
+    '''
     def name_fragment(self, fragment, name, auto=None, force=None, **kwargs):
         """
         Assign a fragment a non-UUID external ref to facilitate its easy retrieval.  I suspect this should be
@@ -85,6 +64,7 @@ class AntelopeForegroundInterface(ForegroundInterface):
         """
         return self._perform_query(_interface, 'name_fragment', ForegroundRequired,
                                    fragment, name, **kwargs)
+    '''
 
     def fragments_with_flow(self, flow, direction=None, reference=None, background=None, **kwargs):
         """
@@ -163,31 +143,6 @@ class AntelopeForegroundInterface(ForegroundInterface):
         """
         return self._perform_query(_interface, 'delete_fragment', ForegroundRequired,
                                    fragment, **kwargs)
-
-    def observe(self, fragment, exchange_value=None, termination=None, name=None, scenario=None, **kwargs):
-        """
-        Observe a fragment's exchange value with respect to its parent activity level.  Only applicable for
-        non-balancing fragments whose parents are processes or foreground nodes (child flows of subfragments have
-        their exchange values determined at traversal, as do balancing flows).
-
-        A fragment should be named when it is observed.  This should replace name_fragment. In a completed model, all
-        observable fragments should have names.
-
-        Also use to define scenario exchange values (or to make replicate observations..).
-
-        scenario and name should be mutually exclusive; if both are supplied, name is ignored.
-
-        :param fragment:
-        :param exchange_value: [this must be the second positional argument for legacy reasons, but can still be None]
-        :param termination:
-        :param name:
-        :param scenario:
-        :param kwargs:
-        :return:
-        """
-        return self._perform_query(_interface, 'observe', ForegroundRequired,
-                                   fragment, exchange_value=exchange_value, termination=termination, name=name,
-                                   scenario=scenario, **kwargs)
 
     def knobs(self, search=None, **kwargs):
         """

--- a/antelope_foreground/interfaces/iforeground.py
+++ b/antelope_foreground/interfaces/iforeground.py
@@ -121,16 +121,15 @@ class AntelopeForegroundInterface(ForegroundInterface):
         return self._perform_query(_interface, 'create_fragment_from_node', ForegroundRequired,
                                    process_ref, ref_flow=ref_flow, include_elementary=include_elementary)
 
-    def clone_fragment(self, frag, **kwargs):
+    def clone_fragment(self, frag, tag=None, **kwargs):
         """
 
         :param frag: the fragment (and subfragments) to clone
-        :param kwargs: suffix (default: ' (copy)', applied to Name of top-level fragment only)
-                       comment (override existing Comment if present; applied to all)
+        :param kwargs: tag - appended to all named child fragments
         :return:
         """
         return self._perform_query(_interface, 'clone_fragment', ForegroundRequired,
-                                   frag, **kwargs)
+                                   frag, tag=tag, **kwargs)
 
     def split_subfragment(self, fragment, replacement=None, **kwargs):
         """
@@ -190,6 +189,15 @@ class AntelopeForegroundInterface(ForegroundInterface):
                                    fragment, exchange_value=exchange_value, termination=termination, name=name,
                                    scenario=scenario, **kwargs)
 
+    def knobs(self, search=None, **kwargs):
+        """
+        Return a list of named fragments whose values can be observed to define scenarios.  Generates a list
+        of non-reference fragments with names
+        :return:
+        """
+        return self._perform_query(_interface, 'knobs', ForegroundRequired,
+                                   search=search, **kwargs)
+
     def set_balance_flow(self, fragment, **kwargs):
         """
         This should get folded into observe
@@ -215,14 +223,14 @@ class AntelopeForegroundInterface(ForegroundInterface):
         return self._perform_query(_interface, 'unset_balance_flow', ForegroundRequired,
                                    fragment, **kwargs)
 
-    def create_process_model(self, process, ref_flow=None, set_background=True, **kwargs):
+    def create_process_model(self, process, ref_flow=None, set_background=None, **kwargs):
         """
         Create a fragment from a process_ref.  If process has only one reference exchange, it will be used automatically.
         By default, a child fragment is created for each exchange not terminated to context, and exchanges terminated
         to nodes are so terminated in the fragment.
         :param process:
         :param ref_flow: specify which exchange to use as a reference
-        :param set_background: [True] whether to terminate the node to background
+        :param set_background: [None] Deprecated. All terminations are "to background".
         :param kwargs:
         :return:
         """

--- a/antelope_foreground/providers/lcforeground.py
+++ b/antelope_foreground/providers/lcforeground.py
@@ -309,13 +309,10 @@ class LcForeground(BasicArchive):
         oldname = frag.link
         try:
             frag.external_ref = name  # will raise PropertyExists if already set
-        except PropertyExists:
-            if force:
-                self._dename_fragment(frag)
-                oldname = frag.link
-                frag.external_ref = name
-            else:
-                raise
+        except PropertyExists:  # don't need force to rename a nonconflicting fragment
+            self._dename_fragment(frag)
+            oldname = frag.link
+            frag.external_ref = name
 
         self._add_ext_ref_mapping(frag)
         self._rename_mechanics(frag, oldname)

--- a/antelope_foreground/providers/lcforeground.py
+++ b/antelope_foreground/providers/lcforeground.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 
 from ..implementations import AntelopeForegroundImplementation as ForegroundImplementation
 
-from antelope import PropertyExists
+from antelope import PropertyExists, q_node_activity
 from antelope_core.archives import BasicArchive, EntityExists, BASIC_ENTITY_TYPES
 from ..entities.fragments import LcFragment
 
@@ -489,6 +489,8 @@ class LcForeground(BasicArchive):
         :param frag:
         :return:
         """
+        if frag.origin != self.ref:
+            raise FragmentMismatch('Fragment belongs to another foreground!')
         if frag.reference_entity is not None:
             frag.unset_parent()
         self._entities.pop(frag.link)

--- a/antelope_foreground/providers/lcforeground.py
+++ b/antelope_foreground/providers/lcforeground.py
@@ -38,7 +38,7 @@ class NonLocalEntity(Exception):
 
 class LcForeground(BasicArchive):
     """
-    An LcForeground is defined by being anchored to a physical directory, which is used to serialize the non-fragment
+    An LcForeground is defined by being anchored to a physical directory, which is used to serialize_grant_spec the non-fragment
     entities.  Also within this directory is a subdirectory called fragments, which is used to store fragments
     individually as files.
 

--- a/antelope_foreground/terminations.py
+++ b/antelope_foreground/terminations.py
@@ -349,22 +349,30 @@ class FlowTermination(object):
     @property
     def term_is_bg(self):
         """
-        Termination is local and background
+        Termination is local and background.  This is deprecated and always returns False.
+
+        (Reason for its existence dates to when 'background' was a user-specified designation, and fragments were
+        often terminated to a singleton-background fragment (fragment with an immediate background node and no children)
+
+        The idea was simply to shorten the list of FragmentFlows generated in a traversal by removing the "connective
+        tissue" fragment that terminated to the singleton background.  Now that background status is automatically
+        determined by number of children, this is not reliable.)
         :return:
         """
-        return self.is_frag and self.is_local and self.term_node.is_background
+        return False
+        # return self.is_frag and self.is_local and self.term_node.is_background
 
     @property
     def is_subfrag(self):
         """
-        Termination is a non-background, non-self fragment.
+        Termination is a non-self fragment.  (we were excluding background frags too but that is outmoded)
         Controversy around whether expression should be:
         self.is_frag and not (self.is_fg or self.is_bg or self.term_is_bg)  [current] or
         self.is_frag and (not self.is_fg) and (not self.is_bg)  [old; seems wrong]
 
         :return:
         """
-        return self.is_frag and not (self.is_fg or self.is_bg or self.term_is_bg)
+        return self.is_frag and not self.is_fg  # or self.is_bg or self.term_is_bg)
 
     @property
     def is_null(self):

--- a/antelope_foreground/tests/test_terminations.py
+++ b/antelope_foreground/tests/test_terminations.py
@@ -46,7 +46,7 @@ class FlowTerminationTestCase(BasicEntityTest):
         self.assertFalse(term.is_null)
         self.assertFalse(term.is_null)
         self.assertFalse(term.is_subfrag)
-        self.assertFalse(term.is_bg)
+        self.assertTrue(term.is_bg)  # bg now means "no child flows"
         self.assertFalse(term.term_is_bg)
 
     def test_unobserved(self):


### PR DESCRIPTION
For CATRA- we wanted to be able to recall fragment flows' inherent directions to distinguish e.g. "negative-magnitude outputs" from inputs. then it snowballed from there