### PR TITLE
Bring virtualize up to speed with master tweaks

### DIFF
--- a/antelope_foreground/entities/fragment_editor.py
+++ b/antelope_foreground/entities/fragment_editor.py
@@ -22,6 +22,7 @@ def create_fragment(flow, direction, parent=None, **kwargs):
 
 
 def _create_fragment(flow, direction, uuid=None, parent=None, name=None, comment=None, value=None, balance=False,
+                     exchange_value=None,
                      **kwargs):
     """
 
@@ -40,6 +41,16 @@ def _create_fragment(flow, direction, uuid=None, parent=None, name=None, comment
     if name is None:
         name = flow['Name']
     name = kwargs.pop('Name', name)
+
+    # handle 'value' vs 'exchange_value' redundancy
+    if value is None:
+        if exchange_value is not None:
+            value = exchange_value
+        # counter-case- pass
+    else:
+        if exchange_value is not None:
+            raise TypeError('Cannot provide both "value" and "exchange_value" inputs')
+        # counter-case- pass
 
     if comment is None:
         comment = ''

--- a/antelope_foreground/entities/fragments.py
+++ b/antelope_foreground/entities/fragments.py
@@ -6,7 +6,7 @@
 import uuid
 # from collections import defaultdict
 
-from antelope import comp_dir, check_direction, PropertyExists, CatalogRef
+from antelope import comp_dir, check_direction, PropertyExists, CatalogRef, RxRef
 
 from ..fragment_flows import group_ios, FragmentFlow, frag_flow_lcia
 from antelope_core.entities import LcEntity, LcFlow
@@ -245,6 +245,13 @@ class LcFragment(LcEntity):
         if level < self.__dbg_threshold:
             print('%.3s %s' % (self.uuid, qwer))
 
+    def reference(self):
+        """
+        For process interoperability
+        :return:
+        """
+        return RxRef(self, self.flow, comp_dir(self.direction), self.get('Comment', None), value=self.observed_ev)
+
     def make_ref(self, query):
         ref = super(LcFragment, self).make_ref(query)
         ref.set_config(self.flow.make_ref(query.cascade(self.flow.origin)), self.direction)
@@ -267,6 +274,8 @@ class LcFragment(LcEntity):
         parent.add_child(self)
 
     def unset_parent(self):
+        if self.is_balance:
+            self.unset_balance_flow()
         self.reference_entity.remove_child(self)
         self._set_reference(None)
 

--- a/antelope_foreground/fragment_flows.py
+++ b/antelope_foreground/fragment_flows.py
@@ -134,7 +134,7 @@ class FragmentFlow(object):
         return name
 
     def __str__(self):
-        return '%.5s  %10.3g [%6s] %s %s' % (self.fragment.uuid, self.node_weight, self.fragment.direction,
+        return '%.5s  %10.3g [%6s] %s %s' % (self.fragment.uuid, self.magnitude, self.fragment.direction,
                                              self.term, self.name)
 
     def __add__(self, other):

--- a/antelope_foreground/implementations/foreground.py
+++ b/antelope_foreground/implementations/foreground.py
@@ -98,6 +98,9 @@ class AntelopeForegroundImplementation(BasicImplementation, AntelopeForegroundIn
         """
         return self._archive.tm.get_canonical(quantity)
 
+    def targets(self, flow, direction, **kwargs):
+        return self.fragments_with_flow(flow, direction, **kwargs)
+
     def _grounded_ref(self, ref, check_etype=None):
         """
         Accept either a string, an unresolved catalog ref, a resolved catalog ref, or an entity
@@ -313,12 +316,12 @@ class AntelopeForegroundImplementation(BasicImplementation, AntelopeForegroundIn
         for k in self._observations:
             yield k
 
-    def fragments_with_flow(self, flow, direction=None, reference=None, background=None, **kwargs):
+    def fragments_with_flow(self, flow, direction=None, reference=True, background=None, **kwargs):
         """
         Requires flow identity
         :param flow:
         :param direction:
-        :param reference:
+        :param reference: {True} | False | None
         :param background:
         :param kwargs:
         :return:

--- a/antelope_foreground/implementations/foreground.py
+++ b/antelope_foreground/implementations/foreground.py
@@ -276,14 +276,21 @@ class AntelopeForegroundImplementation(BasicImplementation, AntelopeForegroundIn
         return self._archive.name_fragment(fragment, name, auto=auto, force=force)
     '''
 
-    def observe(self, fragment, exchange_value=None, name=None, scenario=None, units=None, auto=None, force=None,
+    def observe(self, fragment, exchange_value=None, termination=None, name=None, scenario=None,
+                units=None, auto=None, force=None,
                 accept_all=None, **kwargs):
         if accept_all is not None:
             print('%s: cannot "accept all"' % fragment)
-        if name is not None and scenario is None:  #
-            if fragment.external_ref != name:
-                print('Naming fragment %s -> %s' % (fragment.external_ref, name))
-                self._archive.name_fragment(fragment, name, auto=auto, force=force)
+        if name is not None:
+            if scenario is None:  #
+                if fragment.external_ref != name:
+                    print('Naming fragment %s -> %s' % (fragment.external_ref, name))
+                    self._archive.name_fragment(fragment, name, auto=auto, force=force)
+                else:
+                    # nothing to do
+                    pass
+            else:
+                print('Ignoring fragment name under a scenario specification')
         if fragment.observable(scenario):
             if fragment not in self._observations:
                 self._observations.append(fragment)
@@ -295,6 +302,10 @@ class AntelopeForegroundImplementation(BasicImplementation, AntelopeForegroundIn
                 print('Note: Ignoring exchange value %g for unobservable fragment %s [%s]' % (exchange_value,
                                                                                               fragment.external_ref,
                                                                                               scenario))
+        if termination is not None:
+            term = self.find_term(termination)
+            fragment.terminate(term, scenario=scenario)
+
         return fragment.link
 
     @property

--- a/antelope_foreground/interfaces/iforeground.py
+++ b/antelope_foreground/interfaces/iforeground.py
@@ -165,7 +165,7 @@ class AntelopeForegroundInterface(ForegroundInterface):
         return self._perform_query(_interface, 'delete_fragment', ForegroundRequired,
                                    fragment, **kwargs)
 
-    def observe(self, fragment, exchange_value=None, name=None, scenario=None, **kwargs):
+    def observe(self, fragment, exchange_value=None, termination=None, name=None, scenario=None, **kwargs):
         """
         Observe a fragment's exchange value with respect to its parent activity level.  Only applicable for
         non-balancing fragments whose parents are processes or foreground nodes (child flows of subfragments have
@@ -179,14 +179,16 @@ class AntelopeForegroundInterface(ForegroundInterface):
         scenario and name should be mutually exclusive; if both are supplied, name is ignored.
 
         :param fragment:
-        :param exchange_value:
+        :param exchange_value: [this must be the second positional argument for legacy reasons, but can still be None]
+        :param termination:
         :param name:
         :param scenario:
         :param kwargs:
         :return:
         """
         return self._perform_query(_interface, 'observe', ForegroundRequired,
-                                   fragment, exchange_value, name=name, scenario=scenario, **kwargs)
+                                   fragment, exchange_value=exchange_value, termination=termination, name=name,
+                                   scenario=scenario, **kwargs)
 
     def set_balance_flow(self, fragment, **kwargs):
         """

--- a/antelope_foreground/providers/lcforeground.py
+++ b/antelope_foreground/providers/lcforeground.py
@@ -135,8 +135,6 @@ class LcForeground(BasicArchive):
         self._ext_ref_mapping = dict()
         self._frags_with_flow = defaultdict(set)
 
-        if not os.path.isdir(self.source):
-            os.makedirs(self.source)
         self.load_all()
         self.check_counter('fragment')
 
@@ -384,6 +382,9 @@ class LcForeground(BasicArchive):
                 os.remove(os.path.join(self._fragment_dir, leftover))
 
     def save(self, save_unit_scores=False):
+        if not os.path.isdir(self.source):
+            os.makedirs(self.source)
+
         self.write_to_file(self._archive_file, gzip=False, characterizations=True, values=True, domesticate=False)
         if not os.path.isdir(self._fragment_dir):
             os.makedirs(self._fragment_dir)

--- a/antelope_foreground/terminations.py
+++ b/antelope_foreground/terminations.py
@@ -289,7 +289,7 @@ class FlowTermination(object):
     @property
     def is_local(self):
         """
-        Fragment and termination have the same origin
+        Fragment and termination have the same origin. Implies is_frag, since processes cannot be added to foregrounds
         :return:
         """
         if self.is_null:
@@ -621,7 +621,7 @@ class FlowTermination(object):
             return {}
         if self.is_context:
             j = {
-                'origin': self._term_flow.origin,
+                'origin': 'foreground',
                 'context': self._term.name
             }
         else:
@@ -629,6 +629,9 @@ class FlowTermination(object):
                 'origin': self._term.origin,
                 'externalId': self._term.external_ref
             }
+            if self.is_local:
+                j['origin'] = 'foreground'  # override
+
         # saving term_flow: for subfragments, we save it only it it's specified
         if self.is_frag:
             if self._term_flow is not None:


### PR DESCRIPTION
observe terminations
don't create paths by default
silently handle exchange_value / value in new fragment creation
fragment.reference() fragment.targets()
FragmentFlows should report magnitudes, not node weights
